### PR TITLE
fix(repo-cooker): should depend on dev and peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint \"**/*.js\"",
     "prepublish": "npm run build",
     "pretest": "test -e test/repo || git clone git@github.com:cerebral/repo-cooker-test.git test/repo",
-    "test": "mocha --compilers js:babel-register \"src/**/*.test.js\" \"test/integration/*.test.js\"",
+    "test": "mocha -r test/checkCommits --compilers js:babel-register \"src/**/*.test.js\" \"test/integration/*.test.js\"",
     "test:watch": "npm run test -- --watch"
   },
   "repository": {

--- a/src/Cooker/providers/GithubProvider/index.js
+++ b/src/Cooker/providers/GithubProvider/index.js
@@ -1,12 +1,12 @@
 import { createRelease } from './createRelease'
-import { execCommand } from '../../../helpers/execCommand'
+import { execCommand, logCommand } from '../../../helpers/execCommand'
 
 export function GithubProvider({ path, runCommand }) {
   if (process.env.GITHUB_TOKEN === undefined) {
     const message = `Github provider needs an OAUTH token in env GITHUB_TOKEN.`
     if (runCommand === execCommand) {
       throw new Error(message)
-    } else {
+    } else if (runCommand === logCommand) {
       console.warn(message)
     }
   }

--- a/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.js
+++ b/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.js
@@ -10,7 +10,12 @@ export function getRelatedPackages(config) {
             .readFileSync(join(config.packagesPaths[name], 'package.json'))
             .toString()
         )
-        const dependencies = info.dependencies || {}
+        const dependencies = Object.assign(
+          {},
+          info.peerDependencies || {},
+          info.devDependencies || {},
+          info.dependencies || {}
+        )
         if (info.name !== name) {
           throw new Error(
             `Invalid package.json (name entry '${info.name}' does not match package name '${name}').`

--- a/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.test.js
+++ b/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.test.js
@@ -10,3 +10,19 @@ it('should get related packages by package', function(done) {
     assert.deepEqual(relatedPackages, ['@repo-cooker-test/poissonier'], done)
   })
 })
+
+it('should get read devDependencies', function(done) {
+  const getRelatedPackages = getRelatedPackagesFactory(config)
+
+  getRelatedPackages('@repo-cooker-test/poissonier').then(relatedPackages => {
+    assert.deepEqual(relatedPackages, ['@repo-cooker-test/entremetier'], done)
+  })
+})
+
+it('should get read peerDependencies', function(done) {
+  const getRelatedPackages = getRelatedPackagesFactory(config)
+
+  getRelatedPackages('@repo-cooker-test/pastry-chef').then(relatedPackages => {
+    assert.deepEqual(relatedPackages, ['@repo-cooker-test/sous-chef'], done)
+  })
+})

--- a/src/actions/evaluateNewVersionByPackage.js
+++ b/src/actions/evaluateNewVersionByPackage.js
@@ -1,17 +1,17 @@
 const TYPES = ['major', 'minor', 'patch']
 const RTYPES = ['patch', 'minor', 'major']
-const PART_RE = /^\d+$/
 
-const valid = PART_RE.test.bind(PART_RE)
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)/
 
 function evaluateVersion(version, type, packageName, semver) {
-  const rawParts = version.split('.')
-  if (rawParts.length !== 3 || !rawParts.every(valid)) {
+  const re = VERSION_RE.exec(version)
+  if (!re) {
     throw new Error(
-      `Invalid version '${version}' for package '${packageName}' (format should be '[integer].[integer].[integer]').`
+      `Invalid version '${version}' for package '${packageName}' (format should be '[integer].[integer].[integer][anything]').`
     )
   }
-  const parts = rawParts.map(l => parseInt(l))
+
+  const parts = [re[1], re[2], re[3]].map(l => parseInt(l))
   let idx = TYPES.indexOf(type)
   if (idx < 0) {
     throw new Error(

--- a/src/actions/evaluateNewVersionByPackage.test.js
+++ b/src/actions/evaluateNewVersionByPackage.test.js
@@ -8,15 +8,19 @@ const relatedPackagesByPackage = {
   package2: [],
   package3: [],
   package4: [],
-  package5: ['package1'],
+  package5: ['package7'],
+  package6: [],
+  package7: ['package1'],
 }
 const tests = [
   { current: '0.3.9', type: 'minor', version: '0.4.0' },
   { current: '0.3.9', type: 'major', version: '1.0.0' },
   { current: '1.2.3', type: 'patch', version: '1.2.4' },
   { current: '1.2.3', type: 'minor', version: '1.3.0' },
+  { current: '0.3.9-beta9', type: 'patch', version: '0.3.10' },
+  { current: '0.3.9-34', type: 'patch', version: '1.0.0' },
+  { current: '0.3.9.cd3f34', type: 'patch', version: '0.3.10' },
   { current: '1.2.3', type: 'major', version: '2.0.0' },
-  { current: '0.3.9', type: 'patch', version: '1.0.0' },
 ].reduce(
   (acc, { current, type, version }, idx) => {
     const name = `package${idx}`
@@ -50,7 +54,7 @@ describe('evaluateNewVersionByPackage', () => {
 
   it('should throw error on invalid current version', testDone => {
     const done = error => (error ? testDone(error) : () => {})
-    ;['2.0.0-beta', '4.5.6.7', '1.2.3b', 'ea2356'].forEach(version =>
+    ;['2.f.0-beta', '1.2b.4', 'ea2356'].forEach(version =>
       testActionThrows(
         evaluateNewVersionByPackage,
         {
@@ -58,7 +62,7 @@ describe('evaluateNewVersionByPackage', () => {
           semverByPackage: { foo: 'major' },
           relatedPackagesByPackage: { foo: [] },
         },
-        `Invalid version '${version}' for package 'foo' (format should be '[integer].[integer].[integer]').`,
+        `Invalid version '${version}' for package 'foo' (format should be '[integer].[integer].[integer][anything]').`,
         done
       )
     )

--- a/src/actions/relatedPackagesByPackage.test.js
+++ b/src/actions/relatedPackagesByPackage.test.js
@@ -9,8 +9,8 @@ describe('relatedPackagesByPackage', () => {
       '@repo-cooker-test/commis': ['@repo-cooker-test/poissonier'],
       '@repo-cooker-test/entremetier': [],
       '@repo-cooker-test/executive-chef': [],
-      '@repo-cooker-test/pastry-chef': [],
-      '@repo-cooker-test/poissonier': [],
+      '@repo-cooker-test/pastry-chef': ['@repo-cooker-test/sous-chef'],
+      '@repo-cooker-test/poissonier': ['@repo-cooker-test/entremetier'],
       '@repo-cooker-test/sous-chef': [],
     }
     testAction(

--- a/src/actions/writeVersionsToPackages.test.js
+++ b/src/actions/writeVersionsToPackages.test.js
@@ -4,27 +4,78 @@ import { config, testAction } from 'test-utils'
 import { versions } from 'test-utils/npm'
 import { writeVersionsToPackages } from './'
 
-it('should write new versions to package.json', done => {
-  const currentVersionByPackage = {
-    '@repo-cooker-test/poissonnier': versions['@repo-cooker-test/poissonnier'],
+describe('writeNewVersionsToPackages', () => {
+  const written = {}
+  const dryRun = (cmd, args) => {
+    written[args[0]] = JSON.parse(args[1])
   }
-  const newVersionByPackage = {
-    '@repo-cooker-test/commis': '4.5.6',
-  }
-  const commands = [
-    {
-      cmd: 'writeFile',
-      args: [
-        join(config.packagesPaths['@repo-cooker-test/commis'], 'package.json'),
-        '[data]',
-        { encoding: 'utf8' },
-      ],
-    },
-  ]
-  testAction(
-    writeVersionsToPackages,
-    { newVersionByPackage, currentVersionByPackage },
-    { commands },
-    done
-  )
+
+  it('should write other versions in package.json', done => {
+    const currentVersionByPackage = versions
+    const newVersionByPackage = {
+      '@repo-cooker-test/commis': '4.5.6',
+      '@repo-cooker-test/poissonier': '1.2.3',
+      '@repo-cooker-test/entremetier': '2.3.4',
+      '@repo-cooker-test/pastry-chef': '5.3.4',
+    }
+    const writtenContent = {
+      [join(
+        config.packagesPaths['@repo-cooker-test/commis'],
+        'package.json'
+      )]: {
+        name: '@repo-cooker-test/commis',
+        license: 'MIT',
+        description: '',
+        dependencies: {
+          '@repo-cooker-test/poissonier': '^1.2.3',
+        },
+        scripts: {},
+        version: '4.5.6',
+      },
+      [join(
+        config.packagesPaths['@repo-cooker-test/poissonier'],
+        'package.json'
+      )]: {
+        name: '@repo-cooker-test/poissonier',
+        version: '1.2.3',
+        description: '',
+        devDependencies: {
+          '@repo-cooker-test/entremetier': '^2.3.4',
+        },
+        scripts: {},
+        license: 'MIT',
+      },
+      [join(
+        config.packagesPaths['@repo-cooker-test/entremetier'],
+        'package.json'
+      )]: {
+        name: '@repo-cooker-test/entremetier',
+        version: '2.3.4',
+        description: '',
+        scripts: {},
+        license: 'MIT',
+      },
+      [join(
+        config.packagesPaths['@repo-cooker-test/pastry-chef'],
+        'package.json'
+      )]: {
+        name: '@repo-cooker-test/pastry-chef',
+        version: '5.3.4',
+        description: '',
+        peerDependencies: {
+          '@repo-cooker-test/sous-chef': '^0.3.9',
+        },
+        scripts: {},
+        license: 'MIT',
+      },
+    }
+
+    testAction(
+      writeVersionsToPackages,
+      { newVersionByPackage, currentVersionByPackage, written },
+      { written: writtenContent },
+      done,
+      { dryRun }
+    )
+  })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,12 +1,13 @@
 /* eslint-env mocha */
-import { config } from 'test-utils'
+import { config, runCommandMock } from 'test-utils'
 import { tags } from 'test-utils/commits'
 import assert from 'test-utils/assert'
 import * as cook from './actions'
 import { Cooker } from './'
 
 it('cooks', done => {
-  const cooker = Cooker(config)
+  const dryRun = runCommandMock()
+  const cooker = Cooker(Object.assign({}, config, { dryRun }))
   cooker.run([
     cook.getLatestReleaseHash,
     ({ props }) => {

--- a/test/checkCommits.js
+++ b/test/checkCommits.js
@@ -1,0 +1,39 @@
+import { config } from 'test-utils'
+import { master, commits as testCommits } from 'test-utils/commits'
+import { Cooker } from 'repo-cooker'
+import * as cook from 'repo-cooker/actions'
+
+const cooker = Cooker(Object.assign({}, config, { dryRun: true }))
+
+cooker
+  .run([
+    () => ({ hash: 'Big Bang' }),
+    cook.getHistoryFromHash,
+    cook.getRawCommitsFromHistory,
+    cook.parseCommits,
+    ({ props: { rawCommits, commits } }) => {
+      const head = rawCommits[rawCommits.length - 1].hash
+      if (master !== head) {
+        console.log(
+          "\n\nNEW commits, please update 'test/utils/commits.js' file with:\n"
+        )
+        console.log(`MASTER: ${head}\n`)
+        const newCommits = JSON.stringify(
+          rawCommits.slice(testCommits.length),
+          null,
+          2
+        )
+        console.log(`NEW COMMITS: \n${newCommits}\n`)
+        const newParsedCommits = JSON.stringify(
+          commits.slice(testCommits.length),
+          null,
+          2
+        )
+        console.log(`PARSED COMMITS: \n${newParsedCommits}\n`)
+        process.exit(-1)
+      }
+    },
+  ])
+  .catch(error => {
+    console.log(error)
+  })

--- a/test/utils/commits.js
+++ b/test/utils/commits.js
@@ -11,7 +11,7 @@ export const tags = [
   },
 ]
 
-export const master = 'be939615058a0ebf56d575ff787d1bc5ad668bdd'
+export const master = '492980b1aead601c4391e380f5e61f9d9adabff0'
 
 export const commits = [
   {
@@ -171,6 +171,20 @@ export const commits = [
     hash: 'c15e818703b5e235529beae1973125c1817cc06f',
     message: 'chore(repo-cooker): fix publish script\n',
     files: ['package.json', 'scripts/cooker.js', 'scripts/publish.js'],
+  },
+  {
+    author: {
+      name: 'Gaspard Bucher',
+      email: 'gaspard@lucidogen.io',
+    },
+    date: '2017-07-24T10:58:18.000Z',
+    hash: '492980b1aead601c4391e380f5e61f9d9adabff0',
+    message: 'chore(monorepo): add devDependencies and peerDependencies\n',
+    files: [
+      'packages/node_modules/@repo-cooker-test/commis/package.json',
+      'packages/node_modules/@repo-cooker-test/pastry-chef/package.json',
+      'packages/node_modules/@repo-cooker-test/poissonier/package.json',
+    ],
   },
 ]
 
@@ -402,5 +416,25 @@ export const parsedCommits = [
     type: 'chore',
     scope: 'repo-cooker',
     summary: 'fix publish script',
+  },
+  {
+    author: {
+      name: 'Gaspard Bucher',
+      email: 'gaspard@lucidogen.io',
+    },
+    date: '2017-07-24T10:58:18.000Z',
+    hash: '492980b1aead601c4391e380f5e61f9d9adabff0',
+    message: 'chore(monorepo): add devDependencies and peerDependencies\n',
+    files: [
+      'packages/node_modules/@repo-cooker-test/commis/package.json',
+      'packages/node_modules/@repo-cooker-test/pastry-chef/package.json',
+      'packages/node_modules/@repo-cooker-test/poissonier/package.json',
+    ],
+    body: '',
+    issues: [],
+    breaks: [],
+    type: 'chore',
+    scope: 'monorepo',
+    summary: 'add devDependencies and peerDependencies',
   },
 ]

--- a/test/utils/testAction.js
+++ b/test/utils/testAction.js
@@ -3,9 +3,9 @@ import { config, runCommandMock } from 'test-utils'
 import assert from 'test-utils/assert'
 import { Cooker } from 'repo-cooker'
 
-export function testAction(action, input, output, done) {
+export function testAction(action, input, output, done, extraConfig = {}) {
   const dryRun = runCommandMock()
-  const cooker = Cooker(Object.assign({}, config, { dryRun }))
+  const cooker = Cooker(Object.assign({}, config, { dryRun }, extraConfig))
 
   cooker
     .run([

--- a/test/utils/testActionThrows.js
+++ b/test/utils/testActionThrows.js
@@ -1,11 +1,13 @@
 /* eslint-env mocha */
-import { config } from 'test-utils'
+import { config, runCommandMock } from 'test-utils'
 import assert from 'test-utils/assert'
 import { Cooker } from 'repo-cooker'
 
-export function testActionThrows(action, input, error, done) {
+export function testActionThrows(action, input, error, done, extraConfig = {}) {
+  const dryRun = runCommandMock()
+  const cooker = Cooker(Object.assign({}, config, { dryRun }, extraConfig))
+
   let errorThrown = false
-  const cooker = Cooker(config)
   cooker
     .run([() => input, action])
     .catch(err => {


### PR DESCRIPTION
- [x] Relaxed version checking to `/^\d+\.\d+\.\d+/` (in english this means it should start with number dot number dot number and we do not care if there is any "-beta" or other stuff after).

- [x] Include 'peerDependencies' and 'devDependencies' in `related` dependency bump and also when writing versions to package.json.

- [x] Added a `pretest` script to help update the test/commits file with any new commits.