### PR TITLE
fix(repo-cooker): fix circular dependencies

### DIFF
--- a/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.js
+++ b/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.js
@@ -10,27 +10,26 @@ export function getRelatedPackages(config) {
             .readFileSync(join(config.packagesPaths[name], 'package.json'))
             .toString()
         )
-        const dependencies = Object.assign(
-          {},
-          info.peerDependencies || {},
-          info.devDependencies || {},
-          info.dependencies || {}
-        )
         if (info.name !== name) {
           throw new Error(
             `Invalid package.json (name entry '${info.name}' does not match package name '${name}').`
           )
         }
+        const relatedPackages = {
+          dependencies: [],
+          devDependencies: [],
+          peerDependencies: [],
+        }
 
-        resolve(
-          Object.keys(dependencies).reduce((relatedPackages, dependency) => {
+        Object.keys(relatedPackages).forEach(group =>
+          Object.keys(info[group] || {}).forEach(dependency => {
             if (dependency in config.packagesPaths) {
-              return relatedPackages.concat(dependency)
+              relatedPackages[group].push(dependency)
             }
-
-            return relatedPackages
-          }, [])
+          })
         )
+
+        resolve(relatedPackages)
       } catch (error) {
         reject(error)
       }

--- a/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.test.js
+++ b/src/Cooker/providers/PackageJsonProvider/getRelatedPackages.test.js
@@ -7,22 +7,46 @@ it('should get related packages by package', function(done) {
   const getRelatedPackages = getRelatedPackagesFactory(config)
 
   getRelatedPackages('@repo-cooker-test/commis').then(relatedPackages => {
-    assert.deepEqual(relatedPackages, ['@repo-cooker-test/poissonier'], done)
+    assert.deepEqual(
+      relatedPackages,
+      {
+        dependencies: ['@repo-cooker-test/poissonier'],
+        devDependencies: [],
+        peerDependencies: [],
+      },
+      done
+    )
   })
 })
 
-it('should get read devDependencies', function(done) {
+it('should read devDependencies', function(done) {
   const getRelatedPackages = getRelatedPackagesFactory(config)
 
   getRelatedPackages('@repo-cooker-test/poissonier').then(relatedPackages => {
-    assert.deepEqual(relatedPackages, ['@repo-cooker-test/entremetier'], done)
+    assert.deepEqual(
+      relatedPackages,
+      {
+        dependencies: [],
+        devDependencies: ['@repo-cooker-test/entremetier'],
+        peerDependencies: [],
+      },
+      done
+    )
   })
 })
 
-it('should get read peerDependencies', function(done) {
+it('should read peerDependencies', function(done) {
   const getRelatedPackages = getRelatedPackagesFactory(config)
 
   getRelatedPackages('@repo-cooker-test/pastry-chef').then(relatedPackages => {
-    assert.deepEqual(relatedPackages, ['@repo-cooker-test/sous-chef'], done)
+    assert.deepEqual(
+      relatedPackages,
+      {
+        dependencies: [],
+        devDependencies: [],
+        peerDependencies: ['@repo-cooker-test/sous-chef'],
+      },
+      done
+    )
   })
 })

--- a/src/actions/evaluateNewVersionByPackage.js
+++ b/src/actions/evaluateNewVersionByPackage.js
@@ -37,7 +37,7 @@ export function evaluateNewVersionByPackage({
         ? packageSemverId[packageName]
         : Math.max(
             RTYPES.indexOf(semverByPackage[packageName]),
-            ...relatedPackagesByPackage[packageName].map(resolve)
+            ...relatedPackagesByPackage[packageName].dependencies.map(resolve)
           ))
   const newVersionByPackage = Object.keys(
     semverByPackage

--- a/src/actions/evaluateNewVersionByPackage.test.js
+++ b/src/actions/evaluateNewVersionByPackage.test.js
@@ -2,15 +2,19 @@
 import { testAction, testActionThrows } from 'test-utils'
 import { evaluateNewVersionByPackage } from './'
 
+const noDeps = {
+  dependencies: [],
+}
+
 const relatedPackagesByPackage = {
-  package0: [],
-  package1: [],
-  package2: [],
-  package3: [],
-  package4: [],
-  package5: ['package7'],
-  package6: [],
-  package7: ['package1'],
+  package0: noDeps,
+  package1: noDeps,
+  package2: noDeps,
+  package3: noDeps,
+  package4: noDeps,
+  package5: { dependencies: ['package7'] },
+  package6: noDeps,
+  package7: { dependencies: ['package1'] },
 }
 const tests = [
   { current: '0.3.9', type: 'minor', version: '0.4.0' },
@@ -60,7 +64,7 @@ describe('evaluateNewVersionByPackage', () => {
         {
           currentVersionByPackage: { foo: version },
           semverByPackage: { foo: 'major' },
-          relatedPackagesByPackage: { foo: [] },
+          relatedPackagesByPackage: { foo: noDeps },
         },
         `Invalid version '${version}' for package 'foo' (format should be '[integer].[integer].[integer][anything]').`,
         done
@@ -75,7 +79,7 @@ describe('evaluateNewVersionByPackage', () => {
       {
         currentVersionByPackage: { foo: '0.4.5' },
         semverByPackage: { foo: 'noop' },
-        relatedPackagesByPackage: { foo: [] },
+        relatedPackagesByPackage: { foo: noDeps },
       },
       `Invalid semver type 'noop' for package 'foo'.`,
       done

--- a/src/actions/relatedPackagesByPackage.test.js
+++ b/src/actions/relatedPackagesByPackage.test.js
@@ -4,14 +4,31 @@ import { relatedPackagesByPackage } from './'
 
 describe('relatedPackagesByPackage', () => {
   it('should get related packages for each package', done => {
+    const noDeps = {
+      dependencies: [],
+      devDependencies: [],
+      peerDependencies: [],
+    }
     const relatedPackagesByPackageMap = {
-      'repo-cooker-test': [],
-      '@repo-cooker-test/commis': ['@repo-cooker-test/poissonier'],
-      '@repo-cooker-test/entremetier': [],
-      '@repo-cooker-test/executive-chef': [],
-      '@repo-cooker-test/pastry-chef': ['@repo-cooker-test/sous-chef'],
-      '@repo-cooker-test/poissonier': ['@repo-cooker-test/entremetier'],
-      '@repo-cooker-test/sous-chef': [],
+      'repo-cooker-test': noDeps,
+      '@repo-cooker-test/commis': {
+        dependencies: ['@repo-cooker-test/poissonier'],
+        devDependencies: [],
+        peerDependencies: [],
+      },
+      '@repo-cooker-test/entremetier': noDeps,
+      '@repo-cooker-test/executive-chef': noDeps,
+      '@repo-cooker-test/pastry-chef': {
+        dependencies: [],
+        devDependencies: [],
+        peerDependencies: ['@repo-cooker-test/sous-chef'],
+      },
+      '@repo-cooker-test/poissonier': {
+        dependencies: [],
+        devDependencies: ['@repo-cooker-test/entremetier'],
+        peerDependencies: [],
+      },
+      '@repo-cooker-test/sous-chef': noDeps,
     }
     testAction(
       relatedPackagesByPackage,


### PR DESCRIPTION
We no longer use peerDependencies or devDependencies to compute semver version but we do write the new versions in package.json.