### PR TITLE
fix(npm): allow dist-tag remove to fail

### DIFF
--- a/src/Cooker/providers/NpmProvider/replaceTag.js
+++ b/src/Cooker/providers/NpmProvider/replaceTag.js
@@ -10,8 +10,20 @@ export function replaceTag(config) {
       {
         cwd,
       }
-    ).then(() =>
-      runCommand('npm', ['dist-tag', 'rm', packageName, fromTag], { cwd })
+    ).then(
+      () =>
+        new Promise((resolve, reject) =>
+          // We accept failure for this operation (somehow this happens for no reason
+          // when everything is OK).
+          runCommand('npm', ['dist-tag', 'rm', packageName, fromTag], {
+            cwd,
+          })
+            .then(result => resolve(result))
+            .catch(err => {
+              console.log(err)
+              resolve('')
+            })
+        )
     )
   }
 }

--- a/src/actions/evaluateNewVersionByPackage.js
+++ b/src/actions/evaluateNewVersionByPackage.js
@@ -49,23 +49,25 @@ export function evaluateNewVersionByPackage({
   const newVersionByPackage = Object.keys(
     // We evaluate for all packages related to changed packages
     currentVersionByPackage
-  ).reduce((newVersionByPackage, packageName) => {
-    newVersionByPackage[packageName] =
-      currentVersionByPackage[packageName] === null
-        ? '1.0.0'
-        : semverByPackage[packageName]
-          ? evaluateVersion(
-              currentVersionByPackage[packageName],
-              RTYPES[resolve(packageName)],
-              // Error reporting
-              packageName,
-              semverByPackage[packageName]
-            )
-          : // No semver change: same version.
-            currentVersionByPackage[packageName]
+  )
+    .sort()
+    .reduce((newVersionByPackage, packageName) => {
+      newVersionByPackage[packageName] =
+        currentVersionByPackage[packageName] === null
+          ? '1.0.0'
+          : semverByPackage[packageName]
+            ? evaluateVersion(
+                currentVersionByPackage[packageName],
+                RTYPES[resolve(packageName)],
+                // Error reporting
+                packageName,
+                semverByPackage[packageName]
+              )
+            : // No semver change: same version.
+              currentVersionByPackage[packageName]
 
-    return newVersionByPackage
-  }, {})
+      return newVersionByPackage
+    }, {})
 
   return {
     newVersionByPackage,


### PR DESCRIPTION
this operation has no incidence on release and tends to break