### PR TITLE
fix(run): make npm run throw an error if any scripts fail, better logging

### DIFF
--- a/src/Cooker/index.js
+++ b/src/Cooker/index.js
@@ -79,14 +79,15 @@ export function Cooker(argv, theOptions) {
   ft.cook = (name, ...args) => {
     return ft.run(name, ...args).catch(err => {
       console.log('')
-      console.log(err.payload.error.message)
       console.log(err.payload.error.stack)
-      if (options.devtools) {
+      if (options.useDevtools) {
         // Keep it running
       } else {
         const displayName = typeof name === 'string' ? `${name}: ` : ''
         console.log(`\n\x1b[31m** ${displayName}execution FAILED **\x1b[0m`)
-        process.exit(-1)
+        setTimeout(() => {
+          process.exit(-1)
+        }, 0)
       }
     })
   }

--- a/src/Cooker/providers/NpmProvider/runScript.js
+++ b/src/Cooker/providers/NpmProvider/runScript.js
@@ -1,33 +1,21 @@
-import { readFile } from 'fs'
-import { join } from 'path'
-
-function hasScript(packagePath, scriptName) {
-  return new Promise((resolve, reject) => {
-    readFile(packagePath, 'utf8', (err, data) => {
-      if (err) {
-        reject(err)
-      } else {
-        const info = JSON.parse(data).scripts || {}
-        resolve(!!info[scriptName])
-      }
-    })
-  })
-}
+import { getPackageInfo } from '../PackageJsonProvider/helpers'
 
 export function runScript(config) {
   const { runCommand, packagesPaths } = config
 
   return function runScript(packageName, scriptName, args = []) {
     const cwd = packagesPaths[packageName]
-    return hasScript(join(cwd, 'package.json'), scriptName).then(
-      exists =>
-        exists
-          ? runCommand('npm', ['run', scriptName, ...args], {
-              cwd,
-            })
-              .then(output => ({ pass: true, output }))
-              .catch(error => ({ pass: false, error }))
-          : false
-    )
+    return getPackageInfo(packageName, cwd)
+      .then(info => (info.scripts || {})[scriptName])
+      .then(
+        exists =>
+          exists
+            ? runCommand('npm', ['run', scriptName, ...args], {
+                cwd,
+              })
+                .then(output => ({ pass: true, output }))
+                .catch(error => ({ pass: false, error }))
+            : false
+      )
   }
 }

--- a/src/actions/runNpmScript.js
+++ b/src/actions/runNpmScript.js
@@ -5,12 +5,18 @@ export function runNpmScript(scriptNameTag, args = [], providedPackageNames) {
 
     return Promise.all(
       packages.map(name => npm.runScript(name, scriptName, args))
-    ).then(results => ({
-      [`${scriptName}NpmScript`]: Object.assign(
-        ...results.map((result, idx) => ({
-          [packages[idx]]: result,
-        }))
-      ),
-    }))
+    ).then(results => {
+      const failures = results.filter(result => result && !result.pass)
+      if (failures.length) {
+        throw new Error(`running npm scripts '${scriptName}' failed.`)
+      }
+      return {
+        [`${scriptName}NpmScript`]: Object.assign(
+          ...results.map((result, idx) => ({
+            [packages[idx]]: result,
+          }))
+        ),
+      }
+    })
   }
 }

--- a/src/helpers/execCommand.js
+++ b/src/helpers/execCommand.js
@@ -75,17 +75,16 @@ export function execCommand(cmd, args = [], options) {
     child.stdout.setEncoding('utf-8')
     child.stderr.setEncoding('utf-8')
     child.stdout.on('data', data => {
-      console.log(data)
       out.push(data)
     })
     child.stderr.on('data', data => {
-      console.log(data)
       out.push(data)
     })
     child.on('close', function(code) {
       if (code === 0) {
         logCommand(cmd, args, options)
         console.log(PASS)
+        console.log(out.join('\n'))
         if (pause) {
           setTimeout(() => {
             resolve(out.join('\n'))
@@ -96,6 +95,7 @@ export function execCommand(cmd, args = [], options) {
       } else {
         logCommand(cmd, args, options)
         console.log(FAIL)
+        console.log(out.join('\n'))
         reject(out.join('\n'))
       }
     })

--- a/src/sequences/build.test.js
+++ b/src/sequences/build.test.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import { config, runCommandMock } from 'test-utils'
 
 import { Cooker } from '..'


### PR DESCRIPTION
`npm test` would not fail if any of the packages had failing tests.

Now if any of the `npm run xxx` scripts fails, it throws an error and aborts.