### PR TITLE
Respect build order when publishing

### DIFF
--- a/src/Cooker/index.js
+++ b/src/Cooker/index.js
@@ -93,7 +93,7 @@ export function Cooker(argv, theOptions) {
   }
 
   if (builtin) {
-    ft.cook(`run ${cmd}`, builtin.sequence)
+    ft.cook(`run ${builtin.name}`, builtin.sequence)
   }
   return ft
 }

--- a/src/actions/build.js
+++ b/src/actions/build.js
@@ -1,0 +1,45 @@
+function buildPackages(npm, names) {
+  return Promise.all(names.map(name => npm.runScript(name, 'build'))).then(
+    results => {
+      const failures = results.filter(result => result && !result.pass)
+      if (failures.length) {
+        throw new Error(`running npm scripts 'build' failed.`)
+      }
+      return Object.assign(
+        ...results.map((result, idx) => ({
+          [names[idx]]: result || false, // make sure we do not have undefined here
+        }))
+      )
+    }
+  )
+}
+
+export function build({ props, npm }) {
+  const related = props.relatedPackagesByPackage
+  const built = {}
+  function buildReady(todo) {
+    if (!todo.length) {
+      return Promise.resolve({})
+    }
+
+    const ready = todo.filter(
+      name => related[name].filter(n => built[n] === undefined).length === 0
+    )
+
+    if (!ready.length) {
+      return Promise.reject(
+        new Error(
+          `Cannot build packages: there is a dependency cycle between packages ${JSON.stringify(
+            related
+          )}.`
+        )
+      )
+    }
+
+    return buildPackages(npm, ready).then(results => {
+      Object.assign(built, results)
+      return buildReady(todo.filter(n => built[n] === undefined))
+    })
+  }
+  return buildReady(Object.keys(related)).then(() => ({ build: built }))
+}

--- a/src/actions/fireworks.js
+++ b/src/actions/fireworks.js
@@ -12,8 +12,9 @@ export function fireworks({ config }) {
   console.log(`${color}****************\x1b[0m`)
 }
 
-export function fireworksWithTitle(title) {
-  return function fireWorksWithtitle({ config }) {
+export function fireworksWithTitle(titleOrTag) {
+  return function fireWorksWithtitle({ config, resolve }) {
+    const title = resolve.value(titleOrTag)
     const isReal = config.runCommand === execCommand
     const msg = isReal ? 'SUCCESS !!' : 'DRY RUN OK'
     const color = isReal ? '\x1b[32m' : '\x1b[36m'

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,3 +1,4 @@
+export { build } from './build'
 export { byBranch } from './byBranch'
 export { byReleaseTarget } from './byReleaseTarget'
 export { checkDependencies } from './checkDependencies'

--- a/src/sequences/build.js
+++ b/src/sequences/build.js
@@ -2,12 +2,17 @@ import * as cook from '../actions'
 
 function buildPackages(npm, names) {
   return Promise.all(names.map(name => npm.runScript(name, 'build'))).then(
-    results =>
-      Object.assign(
+    results => {
+      const failures = results.filter(result => result && !result.pass)
+      if (failures.length) {
+        throw new Error(`running npm scripts 'build' failed.`)
+      }
+      return Object.assign(
         ...results.map((result, idx) => ({
           [names[idx]]: result || false, // make sure we do not have undefined here
         }))
       )
+    }
   )
 }
 
@@ -48,6 +53,7 @@ export const buildSequence = [
 ]
 
 export const buildSetup = {
+  name: 'build',
   use: { packageJson: true, npm: true },
   sequence: buildSequence,
 }

--- a/src/sequences/build.js
+++ b/src/sequences/build.js
@@ -1,54 +1,8 @@
 import * as cook from '../actions'
 
-function buildPackages(npm, names) {
-  return Promise.all(names.map(name => npm.runScript(name, 'build'))).then(
-    results => {
-      const failures = results.filter(result => result && !result.pass)
-      if (failures.length) {
-        throw new Error(`running npm scripts 'build' failed.`)
-      }
-      return Object.assign(
-        ...results.map((result, idx) => ({
-          [names[idx]]: result || false, // make sure we do not have undefined here
-        }))
-      )
-    }
-  )
-}
-
-function build({ props, npm }) {
-  const related = props.relatedPackagesByPackage
-  const built = {}
-  function buildReady(todo) {
-    if (!todo.length) {
-      return Promise.resolve({})
-    }
-
-    const ready = todo.filter(
-      name => related[name].filter(n => built[n] === undefined).length === 0
-    )
-
-    if (!ready.length) {
-      return Promise.reject(
-        new Error(
-          `Cannot build packages: there is a dependency cycle between packages ${JSON.stringify(
-            related
-          )}.`
-        )
-      )
-    }
-
-    return buildPackages(npm, ready).then(results => {
-      Object.assign(built, results)
-      return buildReady(todo.filter(n => built[n] === undefined))
-    })
-  }
-  return buildReady(Object.keys(related)).then(() => ({ build: built }))
-}
-
 export const buildSequence = [
   cook.relatedPackagesByPackage,
-  build,
+  cook.build,
   cook.fireworksWithTitle('build'),
 ]
 

--- a/src/sequences/checkDependencies.js
+++ b/src/sequences/checkDependencies.js
@@ -8,6 +8,7 @@ export const checkDependenciesSequence = [
 ]
 
 export const checkDependenciesSetup = {
+  name: 'checkDependencies',
   // Providers that we use for this signal
   use: { packageJson: true },
   sequence: checkDependenciesSequence,

--- a/src/sequences/defaultRelease.js
+++ b/src/sequences/defaultRelease.js
@@ -31,7 +31,7 @@ export const defaultReleaseSequence = [
     otherwise: [],
   },
   cook.writeVersionsToPackages,
-  cook.runNpmScript('prepare'),
+  cook.build,
   cook.publishUnderTemporaryNpmTag,
   cook.byBranch,
   {

--- a/src/sequences/defaultRelease.js
+++ b/src/sequences/defaultRelease.js
@@ -58,5 +58,6 @@ export const defaultReleaseSequence = [
 ]
 
 export const defaultReleaseSetup = {
+  name: 'defaultRelease',
   sequence: defaultReleaseSequence,
 }

--- a/src/sequences/link.js
+++ b/src/sequences/link.js
@@ -3,6 +3,7 @@ import * as cook from '../actions'
 export const linkSequence = [cook.link, cook.fireworksWithTitle('link')]
 
 export const linkSetup = {
+  name: 'link',
   use: {},
   sequence: linkSequence,
 }

--- a/src/sequences/run.js
+++ b/src/sequences/run.js
@@ -2,9 +2,13 @@ import * as cook from '../actions'
 
 import { props } from 'function-tree/tags'
 
-export const runSequence = [cook.runNpmScript(props`cmd`)]
+export const runSequence = [
+  cook.runNpmScript(props`cmd`),
+  cook.fireworksWithTitle('run'),
+]
 
 export const runSetup = {
+  name: 'run',
   use: { npm: true },
   sequence: runSequence,
 }

--- a/src/sequences/run.js
+++ b/src/sequences/run.js
@@ -1,10 +1,10 @@
 import * as cook from '../actions'
 
-import { props } from 'function-tree/tags'
+import { props, string } from 'function-tree/tags'
 
 export const runSequence = [
   cook.runNpmScript(props`cmd`),
-  cook.fireworksWithTitle('run'),
+  cook.fireworksWithTitle(string`run ${props`cmd`}`),
 ]
 
 export const runSetup = {


### PR DESCRIPTION
- Use our internal `build` that respects cross-dependencies.
- Better feedback on run success.
- Fail if any of the builds fail.

```
**************************
**                      **
** run test: SUCCESS !! **
**                      **
**************************
```