### PR TITLE
fix(versioning): write specific versions to packages on release

### DIFF
--- a/src/actions/writeVersionsToPackages.js
+++ b/src/actions/writeVersionsToPackages.js
@@ -12,9 +12,9 @@ function updateField(
     [name]: Object.keys(content[name]).reduce((dependencies, dependency) => {
       dependencies[dependency] =
         dependency in newVersionByPackage
-          ? `^${newVersionByPackage[dependency]}`
+          ? `${newVersionByPackage[dependency]}`
           : dependency in currentVersionByPackage
-            ? `^${currentVersionByPackage[dependency]}`
+            ? `${currentVersionByPackage[dependency]}`
             : currentDeps[dependency]
 
       return dependencies

--- a/src/actions/writeVersionsToPackages.test.js
+++ b/src/actions/writeVersionsToPackages.test.js
@@ -30,7 +30,7 @@ describe('writeVersionsToPackages', () => {
         license: 'MIT',
         description: '',
         dependencies: {
-          '@repo-cooker-test/poissonier': '^1.2.3',
+          '@repo-cooker-test/poissonier': '1.2.3',
         },
         scripts: {
           test: "echo 'test script OK'",
@@ -57,7 +57,7 @@ describe('writeVersionsToPackages', () => {
         version: '5.3.4',
         description: '',
         peerDependencies: {
-          '@repo-cooker-test/sous-chef': '^0.3.9',
+          '@repo-cooker-test/sous-chef': '0.3.9',
         },
         scripts: {
           test: 'exit -1',
@@ -74,7 +74,7 @@ describe('writeVersionsToPackages', () => {
         version: '1.2.3',
         description: '',
         devDependencies: {
-          '@repo-cooker-test/entremetier': '^2.3.4',
+          '@repo-cooker-test/entremetier': '2.3.4',
         },
         scripts: {},
         license: 'MIT',


### PR DESCRIPTION
NPM is unable to evaluate correct versions with ^ on tags, as they have no semver logic to them, it seems. Nevertheless we want specific versions anyways as change to child package indeed makes change to parent packages in regards of versions. So being strict about this relationship is a good thing.

Here is an example trying to install `overmind@next`:

```json
"dependencies": {
    "@types/node": "^10.5.1",
    "action-chain": "^1.0.0-1531909286279",
    "is-plain-object": "^2.0.4",
    "proxy-state-tree": "^1.0.0-1531909286279",
    "tslib": "^1.9.3"
  },
```

This is the `action-chain` that was installed:

```json
 "_requested": {
    "type": "version",
    "registry": true,
    "raw": "action-chain@1.0.0-alpha1",
    "name": "action-chain",
    "escapedName": "action-chain",
    "rawSpec": "1.0.0-alpha1",
    "saveSpec": null,
    "fetchSpec": "1.0.0-alpha1"
  },
  "_requiredBy": [
    "/overmind"
  ],
```

