### PR TITLE
fix(releaseNotes): do not show private packages in release notes

### DIFF
--- a/src/actions/releaseNotes/avatar.js
+++ b/src/actions/releaseNotes/avatar.js
@@ -4,8 +4,9 @@ function createNewVersionsTable(release) {
   const entries = Object.keys(release.newVersionByPackage)
     .filter(packageName => {
       return (
+        release.currentVersionByPackage[packageName] &&
         release.currentVersionByPackage[packageName] !==
-        release.newVersionByPackage[packageName]
+          release.newVersionByPackage[packageName]
       )
     })
     .map(packageName => {


### PR DESCRIPTION
private packages gets version `null`... filtering them out in the release notes. Maybe this should be fixed elsewhere, but yeah. At least it fixes the bug :)