### PR TITLE
Fix tag detection (URGENT)

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/actions')
+module.exports = require('./dist/actions')

--- a/src/Cooker/index.js
+++ b/src/Cooker/index.js
@@ -39,13 +39,16 @@ export function Cooker(argv, theOptions) {
   }
   const config = createConfig(options)
   const use = (builtin ? builtin.use : options.use) || USE_ALL
+  const customProviders = options.providers || {}
   const ft = new FunctionTree(
     Object.assign(
       { config },
       ...Object.keys(use)
         .filter(k => use[k])
         .map(k => ({ [k]: provide(PROVIDER[k], config) })),
-      options.providers || {}
+      ...Object.keys(customProviders).map(k => ({
+        [k]: customProviders[k](config),
+      }))
     )
   )
 

--- a/src/actions/getLatestReleaseHash.js
+++ b/src/actions/getLatestReleaseHash.js
@@ -1,6 +1,8 @@
+export const RELEASE_RE = /[a-zA-Z_]+\d\d\d\d-\d\d-\d\d_\d\d\d\d/
+
 export function getLatestReleaseHash({ git }) {
   return git
-    .getLatestTagMatchingName('release_')
+    .getLatestTagMatchingName(RELEASE_RE)
     .then(tag =>
       tag ? { hash: tag.hash, tag: tag.tag } : { hash: 'Big Bang' }
     )

--- a/src/actions/tagCurrentCommit.js
+++ b/src/actions/tagCurrentCommit.js
@@ -1,10 +1,18 @@
+import { RELEASE_RE } from './getLatestReleaseHash'
+
 export function tagCurrentCommit({ git }) {
   const date = new Date().toISOString()
   const releaseDate = date
     .slice(0, 16)
     .replace('T', '_')
     .replace(':', '')
-  // We have to prefix with "v" due to GitHub constraint
+  // This is used to detect latest release in getLatestReleaseHash
+  // THIS NAME MUST MATCH RELEASE_RE
   const name = `v${releaseDate}`
+  if (!RELEASE_RE.test(name)) {
+    // This should NEVER EVER EVER happen :-)
+    throw new Error(`Tag '${name}' does not match ${RELEASE_RE} !!`)
+  }
+
   return git.createTagForCommit(name).then(() => ({ tag: { name, date } }))
 }


### PR DESCRIPTION
This is an EMERGENCY as now the current repo-cooker will keep releasing without detecting the previous release.
