### PR TITLE
Link in first common folder, small change in command feedback to avoid confusion

### DIFF
--- a/src/actions/link.js
+++ b/src/actions/link.js
@@ -5,7 +5,7 @@ import { resolve } from '../helpers/path'
 import { runAll } from '../helpers/runAll'
 
 // Alias function so that function name is `link`, not `linkOne`.
-const linkOne = function link(packageBin, rootBin) {
+const linkOne = function link(rootBin, packageBin) {
   return new Promise((resolve, reject) => {
     const dir = dirname(packageBin)
     if (!existsSync(dir)) {
@@ -33,8 +33,8 @@ export function link({ config }) {
   return runAll(
     packages.map(name =>
       runCommand(linkOne, [
-        resolve(config.packagesPaths[name], 'node_modules', '.bin'),
         rootBin,
+        resolve(config.packagesPaths[name], 'node_modules', '.bin'),
       ])
     )
   ).then(results => ({

--- a/src/actions/link.test.js
+++ b/src/actions/link.test.js
@@ -21,7 +21,7 @@ it('should link bin directories', function(done) {
     .map(name => config.packagesPaths[name])
     .map(path => ({
       cmd: 'link',
-      args: [resolve(path, 'node_modules', '.bin'), rootBin],
+      args: [rootBin, resolve(path, 'node_modules', '.bin')],
     }))
   testAction(link, {}, { link: linkResults, commands }, done)
 })

--- a/src/actions/linkAsModule.js
+++ b/src/actions/linkAsModule.js
@@ -5,7 +5,7 @@ import { resolve } from '../helpers/path'
 import { runAll } from '../helpers/runAll'
 
 // Alias to show 'linkAsModule'
-const linkOne = function linkAsModule(pkgAsModule, sourcePackage) {
+const linkOne = function linkAsModule(sourcePackage, pkgAsModule) {
   return new Promise((resolve, reject) => {
     const dir = dirname(pkgAsModule)
     if (!existsSync(dir)) {
@@ -33,8 +33,8 @@ export function linkAsModule({ config }) {
   return runAll(
     packages.map(name =>
       runCommand(linkOne, [
-        resolve(nodeModules, name),
         config.packagesPaths[name],
+        resolve(nodeModules, name),
       ])
     )
   ).then(results => ({

--- a/src/actions/linkAsModule.test.js
+++ b/src/actions/linkAsModule.test.js
@@ -21,7 +21,7 @@ it('should link as modules', function(done) {
     .map(name => ({ name, path: config.packagesPaths[name] }))
     .map(({ name, path }) => ({
       cmd: 'linkAsModule',
-      args: [resolve(config.path, 'node_modules', name), path],
+      args: [path, resolve(config.path, 'node_modules', name)],
     }))
   testAction(linkAsModule, {}, { linkAsModule: linkResults, commands }, done)
 })

--- a/src/actions/linkAsModule.test.js
+++ b/src/actions/linkAsModule.test.js
@@ -6,6 +6,18 @@ import { resolve } from '../helpers/path'
 
 it('should link as modules', function(done) {
   this.timeout(4000)
+  const packagesPaths = {
+    '@repo-cooker-test/commis': '/foo/bar/baz/@repo-cooker-test/commis',
+    '@repo-cooker-test/entremetier':
+      '/foo/bar/baz/@repo-cooker-test/entremetier',
+    '@repo-cooker-test/executive-chef':
+      '/foo/bar/baz/@repo-cooker-test/executive-chef',
+    '@repo-cooker-test/pastry-chef':
+      '/foo/bar/baz/@repo-cooker-test/pastry-chef',
+    '@repo-cooker-test/poissonier': '/foo/bar/baz/@repo-cooker-test/poissonier',
+    '@repo-cooker-test/sous-chef': '/foo/bar/baz/@repo-cooker-test/sous-chef',
+    'repo-cooker-test': '/foo/bar/repo-cooker-test',
+  }
   const linkResults = {
     '@repo-cooker-test/commis': 'mock command',
     '@repo-cooker-test/entremetier': 'mock command',
@@ -16,12 +28,49 @@ it('should link as modules', function(done) {
     'repo-cooker-test': 'mock command',
   }
 
-  const rootBin = resolve(config.path, 'node_modules', '.bin')
-  const commands = Object.keys(config.packagesPaths)
-    .map(name => ({ name, path: config.packagesPaths[name] }))
-    .map(({ name, path }) => ({
+  const commands = [
+    { cmd: 'mkdirSync', args: ['/foo/bar/node_modules'] },
+    ...Object.keys(packagesPaths).map(name => ({
       cmd: 'linkAsModule',
-      args: [path, resolve(config.path, 'node_modules', name)],
-    }))
-  testAction(linkAsModule, {}, { linkAsModule: linkResults, commands }, done)
+      args: [packagesPaths[name], resolve('/foo/bar', 'node_modules', name)],
+    })),
+  ]
+  testAction(
+    linkAsModule,
+    { config: { packagesPaths, path: '/foo' } },
+    { linkAsModule: linkResults, commands },
+    done
+  )
+})
+
+it('should skip link as modules if common path contains node_modules', function(done) {
+  this.timeout(4000)
+  testAction(linkAsModule, {}, { linkAsModule: {}, commands: [] }, done)
+})
+
+it('should not link as modules inside part of name', function(done) {
+  this.timeout(4000)
+  const packagesPaths = {
+    '@repo-cooker-test/commis': '/foo/bar/@repo-cooker-test/commis',
+    '@repo-cooker-test/entremetier': '/foo/bar/@repo-cooker-test/entremetier',
+  }
+  const linkResults = {
+    '@repo-cooker-test/commis': 'mock command',
+    '@repo-cooker-test/entremetier': 'mock command',
+  }
+
+  const commands = [
+    // /foo/bar, not /foo/bar/@repo-cooker-test
+    { cmd: 'mkdirSync', args: ['/foo/bar/node_modules'] },
+    ...Object.keys(packagesPaths).map(name => ({
+      cmd: 'linkAsModule',
+      args: [packagesPaths[name], resolve('/foo/bar', 'node_modules', name)],
+    })),
+  ]
+  testAction(
+    linkAsModule,
+    { config: { packagesPaths, path: '/foo' } },
+    { linkAsModule: linkResults, commands },
+    done
+  )
 })

--- a/test/utils/testAction.js
+++ b/test/utils/testAction.js
@@ -17,7 +17,12 @@ export function testAction(
 
   cooker
     .run([
-      () => Object.assign({}, input, { commands: dryRun.commands }),
+      ({ config }) => {
+        if (input.config) {
+          Object.assign(config, input.config)
+        }
+        return Object.assign({}, input, { commands: dryRun.commands })
+      },
       action,
       ({ props }) => {
         assert.deepEqual(


### PR DESCRIPTION
Link in first common folder of all packages. Takes special cases into account, such as packages being already in a `node_modules` and all packages starting with org name `@foo/bar`, `@foo/baz`.

I changed the argument order in internal link and linkAsModule function so that the output mimics `ln` (target first, source last).

This is mostly in case someone reads the output and executes the `ln` commands.