### PR TITLE
feat(releaseNotes): simplify release notes 

### DIFF
--- a/src/actions/createReleaseNotes.test.js
+++ b/src/actions/createReleaseNotes.test.js
@@ -8,6 +8,18 @@ const makeCommit = name => {
 }
 
 it('should run template on release summary', done => {
+  const commits = [
+    'foo_feat_breaks',
+    'foo_fix_breaks',
+    'foo_feat',
+    'foo_fix',
+    'foo_chore',
+    'bar_feat_breaks',
+    'bar_fix_breaks',
+    'bar_feat',
+    'bar_fix',
+    'bar_chore',
+  ].map(makeCommit)
   const commitsByPackage = {
     foo: [
       'foo_feat_breaks',
@@ -41,34 +53,46 @@ it('should run template on release summary', done => {
       newVersionByPackage,
       currentVersionByPackage,
       commitsWithoutPackage,
+      commits,
+      commitsByType: {
+        chore: commits.filter(c => c.type === 'chore'),
+        feat: commits.filter(c => c.type === 'feat'),
+        fix: commits.filter(c => c.type === 'fix'),
+      },
       summary: {
         chore: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_chore'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_chore'].map(makeCommit),
           },
         ],
         feat: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_feat_breaks', 'foo_feat'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_feat_breaks', 'bar_feat'].map(makeCommit),
           },
         ],
         fix: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_fix_breaks', 'foo_fix'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_fix_breaks', 'bar_fix'].map(makeCommit),
           },
         ],
@@ -85,6 +109,7 @@ it('should run template on release summary', done => {
       ),
     }),
     {
+      commits,
       commitsByPackage,
       currentVersionByPackage,
       newVersionByPackage,

--- a/src/actions/groupCommitsByPackage.js
+++ b/src/actions/groupCommitsByPackage.js
@@ -1,7 +1,5 @@
 import { resolve } from '../helpers/path'
 
-let commitsWithoutPackage = []
-
 /*
   By looking at files changed we can match the name of
   the package
@@ -28,7 +26,11 @@ function matchPackage(filePath, config) {
   }
 */
 export function groupCommitsByPackage({ config, props }) {
+  const commits = []
+  const commitsWithoutPackage = []
   return {
+    // we add 'packagesAffected' in commits
+    commits,
     /*
       By looking at file paths change we can identify what packages
       are affected by this change
@@ -38,7 +40,7 @@ export function groupCommitsByPackage({ config, props }) {
         Extract packages affected by matching file path changed with
         defined packages in config
       */
-      const packagesAffected = commit.files
+      const affectedPackages = commit.files
         .reduce((packagesAffected, file) => {
           const packageName = matchPackage(file, config)
           if (packageName && packagesAffected.indexOf(packageName) === -1) {
@@ -57,11 +59,11 @@ export function groupCommitsByPackage({ config, props }) {
 
           return true
         })
-
+      commits.push(Object.assign({}, commit, { affectedPackages }))
       /*
         Put commit into each package array
       */
-      packagesAffected.forEach(packageName => {
+      affectedPackages.forEach(packageName => {
         if (!commitsByPackage[packageName]) {
           commitsByPackage[packageName] = []
         }

--- a/src/actions/releaseNotes/simple.js
+++ b/src/actions/releaseNotes/simple.js
@@ -1,20 +1,20 @@
-function Commit(item) {
+function showCommit(commit) {
   return `
-  - ${item.summary} ${
-    item.issues.length ? '(' + item.issues.join(', ') + ')' : ''
-  } - *${item.author.name}*
-    ${item.breaks
-      .map(item => {
-        return `- ${item}`
+  - ${commit.summary} ${
+    commit.issues.length ? '(' + commit.issues.join(', ') + ')' : ''
+  } - *${commit.author.name}*
+    ${commit.breaks
+      .map(breakInfo => {
+        return `- ${breakInfo}`
       })
       .join('\n')}
 `
 }
 
-function Package(item) {
+function showPackageSummary(packageSummary) {
   return `
-#### ${item.name} - ${item.version}
-  ${item.commits.map(Commit).join('\n')}
+#### ${packageSummary.name} - ${packageSummary.version}
+  ${packageSummary.commits.map(showCommit).join('\n')}
 `
 }
 
@@ -25,7 +25,7 @@ function writeBreaks(breaks) {
 
   return `
 ## ${breaks.length} breaking
-${breaks.map(Package).join('\n')}
+${breaks.map(showPackageSummary).join('\n')}
 ---
 `
 }
@@ -37,7 +37,7 @@ function writeFixes(fix) {
 
   return `
 ## ${fix.length} ${fix.length === 1 ? 'fix' : 'fixes'}
-${fix.map(Package).join('\n')}
+${fix.map(showPackageSummary).join('\n')}
 ---
 `
 }
@@ -49,12 +49,12 @@ function writeFeat(feat) {
 
   return `
 ## ${feat.length} ${feat.length === 1 ? 'feature' : 'features'}
-${feat.map(Package).join('\n')}
+${feat.map(showPackageSummary).join('\n')}
 ---
 `
 }
 
-export function simpleNotes(release, options) {
+export function simpleNotes(release) {
   return `${writeBreaks(release.summary.breaks)}
 ${writeFixes(release.summary.fix)}
 ${writeFeat(release.summary.feat)}


### PR DESCRIPTION
Shows affected packages in a single row, show 'all' if all packages are affected (typical of big monorepo changes).

# Example

## Updated packages

| package | from version | to version |
|:---|:---|:---|
| @forten/theme | 1.0.0 | 2.0.0-1615977575341 |
| @forten/tree | 1.0.0 | 2.0.0-1615977575341 |
| @forten/tree-type | 1.0.0 | 2.0.0-1615977575341 |
| @forten/tree-view | 1.0.0 | 2.0.0-1615977575341 |
| @forten/useragent | 1.0.0 | 2.0.0-1615977575341 |

## :rotating_light: Breaking
| package | summary | commit | issues | author | gravatar |
|:---|:---|:---|:---|:---|---|
| all | fix imports for ESM compatibility, rename api surface to use "block" <ul><li>*API surface has changed, consult TreeConfig and TreeSettings*</li></ul> | 97f49c9 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |

## :fire: Feature change
| package | summary | commit | issues | author | gravatar |
|:---|:---|:---|:---|:---|---|
| all | add support for library click, refactor names to block instead of node | 94d2947 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |
| all | fix imports for ESM compatibility, rename api surface to use "block" | 7f49c98 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |
| @forten/tree, @forten/tree-view | add support for library click | 8493729 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |

## :wrench: Chores
| package | summary | commit | issues | author | gravatar |
|:---|:---|:---|:---|:---|---|
| all | update typescript version and cleanup ts build | 8830b3 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |
| @forten/preferences | fix dependencies | d780b18 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |
| monorepo | upgrade to latest repo-cooker so that module linking happens out of root node_modules | 9181390 |  | Maia Taewana | ![Maia Taewana](https://www.gravatar.com/avatar/8844020af097784bc91cdb55c0f55b1f?s=40) |