### PR TITLE
feat(BLM): use 'main' instead of 'master'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js: '14'
 cache:
   directories:
-  - node_modules
+    - node_modules
 git:
   depth: 9999
 addons:
@@ -17,26 +17,26 @@ notifications:
 env:
   - TEST_MODE=serial
 script:
-- |
-  if [[ $SKIP_TESTS != 'true' ]]; then
-    npm prune
-    npm run lint
-    npm test
-  fi
+  - |
+    if [[ $SKIP_TESTS != 'true' ]]; then
+      npm prune
+      npm run lint
+      npm test
+    fi
 after_success:
-- |
-  if [[ $TRAVIS_SECURE_ENV_VARS == 'true' ]]; then
-    git remote set-url origin https://cerebraljs:${GH_TOKEN}@github.com/cerebral/repo-cooker;
-    git config --global user.email "cerebraljs@gmail.com";
-    git config --global user.name "Cerebral JS";
-  fi
-  if [[ $TRAVIS_BRANCH == 'master' || $TRAVIS_PULL_REQUEST == 'true' ]]; then
-    npm run coverage;
-  fi
-  if [[ $TRAVIS_BRANCH == 'master' ]] && [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then
-    printf "//registry.npmjs.org/:_authToken=$NPM_TOKEN\n" > ~/.npmrc
-    npm run release
-  fi
+  - |
+    if [[ $TRAVIS_SECURE_ENV_VARS == 'true' ]]; then
+      git remote set-url origin https://cerebraljs:${GH_TOKEN}@github.com/cerebral/repo-cooker;
+      git config --global user.email "cerebraljs@gmail.com";
+      git config --global user.name "Cerebral JS";
+    fi
+    if [[ $TRAVIS_BRANCH == 'main' || $TRAVIS_PULL_REQUEST == 'true' ]]; then
+      npm run coverage;
+    fi
+    if [[ $TRAVIS_BRANCH == 'main' ]] && [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then
+      printf "//registry.npmjs.org/:_authToken=$NPM_TOKEN\n" > ~/.npmrc
+      npm run release
+    fi
 branches:
   except:
-  - "/^v\\d+\\.\\d+\\.\\d+$/"
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cooker.cook('publish', [
 ])
 ```
 
-For now look at [publish.test.js](https://github.com/cerebral/repo-cooker/blob/master/test/integration/publish.test.js)
+For now look at [publish.test.js](https://github.com/cerebral/repo-cooker/blob/main/test/integration/publish.test.js)
 for a full example with comments.
 
 [npm-image]: https://img.shields.io/npm/v/repo-cooker.svg?style=flat

--- a/src/Cooker/providers/GitProvider/getBranches.test.js
+++ b/src/Cooker/providers/GitProvider/getBranches.test.js
@@ -5,15 +5,15 @@ import { commits } from 'test-utils/commits'
 import { getBranches } from './getBranches'
 
 it('should return branches information', done => {
-  const master = commits[commits.length - 1]
+  const commit = commits[commits.length - 1]
   getBranches(config.path).then(branches => {
     assert.deepEqual(
       branches,
       [
         {
-          date: master.date,
+          date: commit.date,
           name: 'next',
-          hash: master.hash,
+          hash: commit.hash,
         },
       ],
       done

--- a/src/Cooker/providers/GitProvider/getCurrentBranch.test.js
+++ b/src/Cooker/providers/GitProvider/getCurrentBranch.test.js
@@ -5,14 +5,14 @@ import { commits } from 'test-utils/commits'
 import { getCurrentBranch } from './getCurrentBranch'
 
 it('should return information on current branch', done => {
-  const master = commits[commits.length - 1]
+  const commit = commits[commits.length - 1]
   getCurrentBranch(config.path).then(branch => {
     assert.deepEqual(
       branch,
       {
-        date: master.date,
+        date: commit.date,
         name: 'next',
-        hash: master.hash,
+        hash: commit.hash,
       },
       done
     )

--- a/src/Cooker/providers/GitProvider/getHashListFromHash.test.js
+++ b/src/Cooker/providers/GitProvider/getHashListFromHash.test.js
@@ -4,7 +4,7 @@ import assert from 'test-utils/assert'
 import { commits } from 'test-utils/commits'
 import { getHashListFromHash } from './getHashListFromHash'
 
-it('should return hash list up to master', done => {
+it('should return hash list up to hash', done => {
   const hash = commits[0].hash
   getHashListFromHash(config.path, hash).then(list => {
     assert.deepEqual(
@@ -25,7 +25,7 @@ it('should return full history for Big Bang pseudo-hash', done => {
   })
 })
 
-it('should return empty list for master', done => {
+it('should return empty list for last', done => {
   const hash = commits[commits.length - 1].hash
   getHashListFromHash(config.path, hash).then(list => {
     assert.deepEqual(list, [], done)

--- a/src/Cooker/providers/GitProvider/resetRepository.js
+++ b/src/Cooker/providers/GitProvider/resetRepository.js
@@ -18,6 +18,6 @@ export function resetRepository(path, type, ref) {
   return nodegit.Repository.open(path).then(repo =>
     nodegit.Reference.nameToId(repo, ref)
       .then(oid => repo.getCommit(oid))
-      .then(commit => nodegit.Reset(repo, commit, gitType, {}, 'master'))
+      .then(commit => nodegit.Reset(repo, commit, gitType, {}))
   )
 }

--- a/src/Cooker/providers/GithubProvider/index.js
+++ b/src/Cooker/providers/GithubProvider/index.js
@@ -13,9 +13,9 @@ export function GithubProvider({ path, runCommand }) {
   }
 
   return new Provider({
-    createRelease(tagName, body, target = 'master') {
+    createRelease(tagName, body) {
       // Has side effects so we wrap with runCommand
-      return runCommand(createRelease, [path, tagName, body, target])
+      return runCommand(createRelease, [path, tagName, body])
     },
   })
 }

--- a/src/actions/createGithubRelease.test.js
+++ b/src/actions/createGithubRelease.test.js
@@ -8,7 +8,7 @@ it('should post new release to github', done => {
   const commands = [
     {
       cmd: 'createRelease',
-      args: [config.path, tag.name, releaseNotes, 'master'],
+      args: [config.path, tag.name, releaseNotes],
     },
   ]
   testAction(createGithubRelease, { releaseNotes, tag }, { commands }, done)

--- a/src/actions/createReleaseNotes.test.js
+++ b/src/actions/createReleaseNotes.test.js
@@ -8,6 +8,18 @@ const makeCommit = name => {
 }
 
 it('should run template on release summary', done => {
+  const commits = [
+    'foo_feat_breaks',
+    'foo_fix_breaks',
+    'foo_feat',
+    'foo_fix',
+    'foo_chore',
+    'bar_feat_breaks',
+    'bar_fix_breaks',
+    'bar_feat',
+    'bar_fix',
+    'bar_chore',
+  ].map(makeCommit)
   const commitsByPackage = {
     foo: [
       'foo_feat_breaks',
@@ -41,34 +53,46 @@ it('should run template on release summary', done => {
       newVersionByPackage,
       currentVersionByPackage,
       commitsWithoutPackage,
+      commits,
+      commitsByType: {
+        chore: commits.filter(c => c.type === 'chore'),
+        feat: commits.filter(c => c.type === 'feat'),
+        fix: commits.filter(c => c.type === 'fix'),
+      },
       summary: {
         chore: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_chore'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_chore'].map(makeCommit),
           },
         ],
         feat: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_feat_breaks', 'foo_feat'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_feat_breaks', 'bar_feat'].map(makeCommit),
           },
         ],
         fix: [
           {
             name: 'foo',
+            version: 'new.foo.version',
             commits: ['foo_fix_breaks', 'foo_fix'].map(makeCommit),
           },
           {
             name: 'bar',
+            version: 'new.bar.version',
             commits: ['bar_fix_breaks', 'bar_fix'].map(makeCommit),
           },
         ],
@@ -85,6 +109,7 @@ it('should run template on release summary', done => {
       ),
     }),
     {
+      commits,
       commitsByPackage,
       currentVersionByPackage,
       newVersionByPackage,

--- a/src/actions/getBranches.test.js
+++ b/src/actions/getBranches.test.js
@@ -4,16 +4,16 @@ import { commits } from 'test-utils/commits'
 import { getBranches } from './'
 
 it('should list branches', done => {
-  const master = commits[commits.length - 1]
+  const commit = commits[commits.length - 1]
   testAction(
     getBranches,
     {},
     {
       branches: [
         {
-          date: master.date,
+          date: commit.date,
           name: 'next',
-          hash: master.hash,
+          hash: commit.hash,
         },
       ],
     },

--- a/src/actions/getCurrentBranch.test.js
+++ b/src/actions/getCurrentBranch.test.js
@@ -4,15 +4,15 @@ import { commits } from 'test-utils/commits'
 import { getCurrentBranch } from './'
 
 it('should find the name of the current branch', done => {
-  const master = commits[commits.length - 1]
+  const commit = commits[commits.length - 1]
   testAction(
     getCurrentBranch,
     {},
     {
       branch: {
-        date: master.date,
+        date: commit.date,
         name: 'next',
-        hash: master.hash,
+        hash: commit.hash,
       },
     },
     done

--- a/src/actions/groupCommitsByPackage.js
+++ b/src/actions/groupCommitsByPackage.js
@@ -1,7 +1,5 @@
 import { resolve } from '../helpers/path'
 
-let commitsWithoutPackage = []
-
 /*
   By looking at files changed we can match the name of
   the package
@@ -28,7 +26,11 @@ function matchPackage(filePath, config) {
   }
 */
 export function groupCommitsByPackage({ config, props }) {
+  const commits = []
+  const commitsWithoutPackage = []
   return {
+    // we add 'packagesAffected' in commits
+    commits,
     /*
       By looking at file paths change we can identify what packages
       are affected by this change
@@ -38,7 +40,7 @@ export function groupCommitsByPackage({ config, props }) {
         Extract packages affected by matching file path changed with
         defined packages in config
       */
-      const packagesAffected = commit.files
+      const affectedPackages = commit.files
         .reduce((packagesAffected, file) => {
           const packageName = matchPackage(file, config)
           if (packageName && packagesAffected.indexOf(packageName) === -1) {
@@ -57,11 +59,11 @@ export function groupCommitsByPackage({ config, props }) {
 
           return true
         })
-
+      commits.push(Object.assign({}, commit, { affectedPackages }))
       /*
         Put commit into each package array
       */
-      packagesAffected.forEach(packageName => {
+      affectedPackages.forEach(packageName => {
         if (!commitsByPackage[packageName]) {
           commitsByPackage[packageName] = []
         }

--- a/src/actions/releaseNotes/simple.js
+++ b/src/actions/releaseNotes/simple.js
@@ -1,20 +1,20 @@
-function Commit(item) {
+function showCommit(commit) {
   return `
-  - ${item.summary} ${
-    item.issues.length ? '(' + item.issues.join(', ') + ')' : ''
-  } - *${item.author.name}*
-    ${item.breaks
-      .map(item => {
-        return `- ${item}`
+  - ${commit.summary} ${
+    commit.issues.length ? '(' + commit.issues.join(', ') + ')' : ''
+  } - *${commit.author.name}*
+    ${commit.breaks
+      .map(breakInfo => {
+        return `- ${breakInfo}`
       })
       .join('\n')}
 `
 }
 
-function Package(item) {
+function showPackageSummary(packageSummary) {
   return `
-#### ${item.name} - ${item.version}
-  ${item.commits.map(Commit).join('\n')}
+#### ${packageSummary.name} - ${packageSummary.version}
+  ${packageSummary.commits.map(showCommit).join('\n')}
 `
 }
 
@@ -25,7 +25,7 @@ function writeBreaks(breaks) {
 
   return `
 ## ${breaks.length} breaking
-${breaks.map(Package).join('\n')}
+${breaks.map(showPackageSummary).join('\n')}
 ---
 `
 }
@@ -37,7 +37,7 @@ function writeFixes(fix) {
 
   return `
 ## ${fix.length} ${fix.length === 1 ? 'fix' : 'fixes'}
-${fix.map(Package).join('\n')}
+${fix.map(showPackageSummary).join('\n')}
 ---
 `
 }
@@ -49,12 +49,12 @@ function writeFeat(feat) {
 
   return `
 ## ${feat.length} ${feat.length === 1 ? 'feature' : 'features'}
-${feat.map(Package).join('\n')}
+${feat.map(showPackageSummary).join('\n')}
 ---
 `
 }
 
-export function simpleNotes(release, options) {
+export function simpleNotes(release) {
   return `${writeBreaks(release.summary.breaks)}
 ${writeFixes(release.summary.fix)}
 ${writeFeat(release.summary.feat)}

--- a/src/sequences/defaultRelease.js
+++ b/src/sequences/defaultRelease.js
@@ -1,6 +1,15 @@
 import * as cook from '../actions'
 import { logCommand } from '../helpers/execCommand'
 
+const publishToGithub = [
+  cook.tagCurrentCommit,
+  cook.pushTagToRemote,
+  cook.byReleaseTarget,
+  {
+    github: cook.createGithubRelease,
+  },
+]
+
 export const defaultReleaseSequence = [
   // Make sure the release target is valid before running anything.
   cook.byReleaseTarget,
@@ -37,6 +46,7 @@ export const defaultReleaseSequence = [
   cook.byBranch,
   {
     master: cook.mapTemporaryNpmTagTo('latest'),
+    main: cook.mapTemporaryNpmTagTo('latest'),
     next: cook.mapTemporaryNpmTagTo('next'),
     canary: cook.mapTemporaryNpmTagTo('canary'),
     otherwise: [],
@@ -45,14 +55,8 @@ export const defaultReleaseSequence = [
   cook.createReleaseNotes('avatar'),
   cook.byBranch,
   {
-    master: [
-      cook.tagCurrentCommit,
-      cook.pushTagToRemote,
-      cook.byReleaseTarget,
-      {
-        github: cook.createGithubRelease,
-      },
-    ],
+    master: publishToGithub,
+    main: publishToGithub,
     otherwise: [
       ({ git }) => {
         return git.getCurrentBranch().then(branch => {

--- a/test/integration/before.test.js
+++ b/test/integration/before.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import { config } from 'test-utils'
-import { master, commits as testCommits } from 'test-utils/commits'
+import { current, commits as testCommits } from 'test-utils/commits'
 import { Cooker } from 'repo-cooker'
 import * as cook from 'repo-cooker/actions'
 
@@ -14,11 +14,11 @@ before(done => {
       cook.parseCommits,
       ({ props: { rawCommits, commits } }) => {
         const head = commits[commits.length - 1].hash
-        if (master !== head) {
+        if (current !== head) {
           console.log(
             "\n\nNEW commits, please update 'test/utils/commits.js' file with:\n"
           )
-          console.log(`MASTER: ${head}\n`)
+          console.log(`CURRENT: ${head}\n`)
           const newCommits = JSON.stringify(
             rawCommits.slice(testCommits.length),
             null,

--- a/test/integration/publish.test.js
+++ b/test/integration/publish.test.js
@@ -101,7 +101,7 @@ describe('publish script', () => {
       },
       {
         cmd: 'createRelease',
-        args: [basePath, 'v2017-07-09_1906', 'some release notes', 'master'],
+        args: [basePath, 'v2017-07-09_1906', 'some release notes'],
       },
     ]
 
@@ -112,8 +112,8 @@ describe('publish script', () => {
         cook.getLatestReleaseHash,
         // { hash: "e654cd..." }
 
-        // Get list of commit hashes from `props.hash` to master. If `props.hash` is 'Big Bang', returns
-        // the full history up to current master. An invalid hash returns an empty list.
+        // Get list of commit hashes from `props.hash` to release hash. If `props.hash` is 'Big Bang', returns
+        // the full history up to current commit. An invalid hash returns an empty list.
         cook.getHistoryFromHash,
         // { history: ["c456e...", "4d76f..."] }
 

--- a/test/utils/commits.js
+++ b/test/utils/commits.js
@@ -11,7 +11,7 @@ export const tags = [
   },
 ]
 
-export const master = '60e29c9dd656504be9c515c553637cf532c6def3'
+export const current = '60e29c9dd656504be9c515c553637cf532c6def3'
 
 export const commits = [
   {


### PR DESCRIPTION
Add support for publishing with **main** branch to follow on the trend to remove slavery references from tech jargon.

![image](https://user-images.githubusercontent.com/79422935/111648099-ecc0cf00-8867-11eb-8b6b-567406cfb44d.png)

The default release will continue to detect 'master' branch so this is not a breaking change.